### PR TITLE
select command on click on download page

### DIFF
--- a/templates/download.tmpl
+++ b/templates/download.tmpl
@@ -75,5 +75,8 @@
             window.location = $form.attr("action");
             return false;
         });
+
+        $wget.click(function() {this.select();});
+        $curl.click(function() {this.select();});
     });
 </script>


### PR DESCRIPTION
Small user interface tweak: automatically select command, when user clicks in input field on download page.
